### PR TITLE
Add the ability to have a timeout for redis, by default the client wo…

### DIFF
--- a/redisstorage.go
+++ b/redisstorage.go
@@ -26,6 +26,9 @@ type Storage struct {
 	// Expires is when the item saved to redis will expire
 	Expires time.Duration
 
+	//ClientTimeOut is to set when the application client connections will timeout and close
+	ClientTimeOut time.Duration
+
 	mu sync.RWMutex // Only used for cookie methods.
 }
 
@@ -33,9 +36,10 @@ type Storage struct {
 func (s *Storage) Init() error {
 	if s.Client == nil {
 		s.Client = redis.NewClient(&redis.Options{
-			Addr:     s.Address,
-			Password: s.Password,
-			DB:       s.DB,
+			Addr:       s.Address,
+			Password:   s.Password,
+			DB:         s.DB,
+			MaxConnAge: s.ClientTimeOut,
 		})
 	}
 	_, err := s.Client.Ping().Result()


### PR DESCRIPTION
We are seeing climbing memory usage in web crawler this is in the read-write buffers for Redis client. My guess is that the issue is due to the clients living forever keeping their data in the buffer. Closing the connection for idle clients should help reduce the buffer size.

@vendasta/data-team 